### PR TITLE
Add `gke.await_job` to the workflow to ensure the workflow waits for the GKE Job to finish before completing, like the others (Batch API, Trancsoder API)..

### DIFF
--- a/workflows/upload-event-workflow.yaml
+++ b/workflows/upload-event-workflow.yaml
@@ -386,7 +386,17 @@
                 location: ${LOCATION}
                 job: ${request.job}
             result: gkejob
+        - await_k8s_job:
+            call: gke.await_job
+            args: 
+                cluster_id: ${GKE_CLUSTER_NAME}
+                job_name: ${gkejob.metadata.name}
+                namespace: ${GKE_NAMESPACE}
+                project: ${PROJECT}
+                location: ${LOCATION}
+                timeout: 1000
+            result: gkefinishedjob
         - result:
             return: 
               request: ${request}
-              response: ${gkejob}
+              response: ${gkefinishedjob}


### PR DESCRIPTION
workflow waits for the GKE Job to finish.