### PR TITLE
Using shell substitution instead of && or ||

### DIFF
--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -35,7 +35,8 @@ if [ $GH_AVAILABLE ]; then
 fi
 _GCP_SA_GITHUB_ACTIONS="sa-tf-gh-actions"
 _GCP_PROJECT_ID=$(gcloud config get-value project)
-_GCP_LOCATION=$(gcloud config get-value compute/region && echo "us-central1")
+_GCP_LOCATION=$(gcloud config get-value compute/region)
+_GCP_LOCATION=${_GCP_LOCATION:-us-central1}
 _GCP_CUSTOMER_ID="gcp"
 
 # Request acceptance of defaults or alternatives


### PR DESCRIPTION
…doing this.

if gcloud region is "unset" then we default to us-central, otherwise we use its value.